### PR TITLE
Adds the concept of "send/receive"

### DIFF
--- a/gapi/static/package-lock.json
+++ b/gapi/static/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "static",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -2447,6 +2446,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",

--- a/gapi/virtual_hosts/mod.go
+++ b/gapi/virtual_hosts/mod.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -12,24 +13,57 @@ const dataFormat = "data:{\"timeSent\":\"%d\", \"toAddr\":\"%s\"}\nid:%d\n\n"
 
 const n = 3
 
-// var messages = sync.Map{}
-// var idSent = 0
+func newNodes(n int) *nodes {
+	s := make(map[int]node)
+
+	for i := 1; i <= n; i++ {
+		s[i] = newNode()
+	}
+
+	return &nodes{
+		s: s,
+	}
+}
+
+type nodes struct {
+	sync.Mutex
+	s map[int]node
+}
+
+func (n *nodes) get(i int) node {
+	n.Lock()
+	defer n.Unlock()
+
+	return n.s[i]
+}
+
+func newNode() node {
+	return node{
+		incomings: make(chan string, 100),
+	}
+}
+
+type node struct {
+	incomings chan string
+}
 
 func main() {
 
+	nodes := newNodes(n)
+
 	// Show on console the application stated
-	main_server := http.NewServeMux()
-	main_server.Handle("/", http.FileServer(http.Dir("../static")))
+	mainServer := http.NewServeMux()
+	mainServer.Handle("/", http.FileServer(http.Dir("../static")))
 
 	// Creating sub-domain
 	server := http.NewServeMux()
 
 	for i := 1; i <= n; i++ {
-		server.HandleFunc(fmt.Sprintf("/%d/sent", i), getServerFunc)
+		server.HandleFunc(fmt.Sprintf("/%d/sent", i), getSentFunc(nodes, i))
 	}
 
 	for i := 1; i <= n; i++ {
-		server.HandleFunc(fmt.Sprintf("/%d/recv", i), getServerFunc)
+		server.HandleFunc(fmt.Sprintf("/%d/recv", i), getRecvFunc(nodes.get(i)))
 	}
 
 	printConfig()
@@ -37,75 +71,79 @@ func main() {
 	go http.ListenAndServe("localhost:8081", server)
 
 	// Running Main Server
-	http.ListenAndServe("localhost:8080", main_server)
+	http.ListenAndServe("localhost:8080", mainServer)
 }
 
-func getServerFunc(w http.ResponseWriter, r *http.Request) {
+func getSentFunc(nodes *nodes, nodeIndex int) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := 0
+		flusher, ok := w.(http.Flusher)
 
-	id := 0
-	// path := r.URL.Path
-	// node := path[:len(path)-4]
-	// event := path[len(path)-4:]
-
-	flusher, ok := w.(http.Flusher)
-
-	if !ok {
-		http.Error(w, "Streaming unsupported!", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-
-	for {
-		select {
-		case <-time.After(time.Millisecond * 500 /** time.Duration(rand.Intn(10))*/):
-			randomDest := fmt.Sprintf("127.0.0.1:%04d", rand.Intn(n)+1)
-			message := fmt.Sprintf(dataFormat, time.Now().UnixMilli(), randomDest, id)
-			fmt.Fprint(w, message)
-			flusher.Flush()
-			id++
-			// 	fmt.Fprint(w, message)
-			// 	message := fmt.Sprintf(dataFormat, time.Now().UnixMilli(), randomDest, id)
-			// 	fmt.Fprint(w, message)
-			// if event == "sent" {
-			// 	randomDest := fmt.Sprintf("127.0.0.1:%04d", rand.Intn(n)+1)
-			// 	message := fmt.Sprintf(dataFormat, time.Now().UnixMilli(), randomDest, id)
-			// 	fmt.Fprint(w, message)
-			// 	flusher.Flush()
-			// 	fmt.Println(node)
-			// 	// arr, ok := messages.Load(node)
-			// 	// arr2 := arr.([]interface{})
-			// 	// if ok {
-			// 	// 	arr := append([]interface{}{arr}, message)
-			// 	// 	messages.Store(node, arr)
-			// 	// 	fmt.Println(messages.Load(node))
-			// 	// } else {
-			// 	// 	messages.Store(node, []interface{}{message})
-			// 	// 	fmt.Println(messages.Load(node))
-			// 	// }
-			// 	id++
-			// }
-			// else if event == "recv" {
-			// 	fmt.Fprint(w, me
-			// 	// for len(messages[path]) > 0 {
-			// 	// 	n := len(messages[path]) - 1
-			// 	// 	fmt.Fprint(w, messages[path][n])
-			// 	// 	messages[path] = messages[path][:n]
-			// 	// 	flusher.Flush()
-			// 	// }
-			// 	// for i := idRecv; i < idSent; i++ {
-			// 	// 	fmt.Fprint(w, messages[path][i])
-			// 	// 	idRecv++
-			// 	// }
-			// } else {
-			// 	http.Error(w, "page not found", http.StatusNotFound)
-			// }
-
-		case <-r.Context().Done():
+		if !ok {
+			http.Error(w, "Streaming unsupported!", http.StatusInternalServerError)
 			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		for {
+			select {
+			case <-time.After(time.Millisecond * 500 /** time.Duration(rand.Intn(10))*/):
+				destIndex := rand.Intn(n) + 1
+				randomDest := fmt.Sprintf("127.0.0.1:%04d", destIndex)
+
+				message := fmt.Sprintf(dataFormat, time.Now().UnixMilli(), randomDest, id)
+				fmt.Fprint(w, message)
+				flusher.Flush()
+
+				go func(node node, id int) {
+					sourceAddr := fmt.Sprintf("127.0.0.1:%04d", nodeIndex)
+					message := fmt.Sprintf(dataFormat, time.Now().UnixMilli(), sourceAddr, id)
+
+					// notify the receiving node after 1 second
+					time.Sleep(time.Second)
+					node.incomings <- message
+				}(nodes.get(destIndex), id)
+
+				id++
+
+			case <-r.Context().Done():
+				return
+			}
+		}
+	}
+}
+
+// getRecvFunc listen on the incoming channel of the node and return the
+// received message. Must be called only once per node.
+func getRecvFunc(node node) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		flusher, ok := w.(http.Flusher)
+
+		if !ok {
+			http.Error(w, "Streaming unsupported!", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+
+		for {
+			select {
+			case msg := <-node.incomings:
+				fmt.Println("message received:", msg)
+				fmt.Fprint(w, msg)
+				flusher.Flush()
+
+			case <-r.Context().Done():
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
You can subscribe to `/<i>/recv` and get notified when a node receives a message corresponding to a previously sent message. The "toAddr" will correspond to the node's address that originally sent the message.
The system fires "recv" message 1 second after the message has been sent, i.e if A sends a message to B, B will tell after 1 second that it received a message from A.